### PR TITLE
Add manual bucket name input when ListBuckets is denied

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -130,6 +130,11 @@ pub struct App {
     // Preview state (triggered explicitly with 'p')
     pub preview: preview::PreviewState,
 
+    // Manual bucket name input (when ListBuckets is denied)
+    pub bucket_input_active: bool,
+    pub bucket_input: String,
+    pub(crate) bucket_input_remote: Option<String>,
+
     pub(crate) config: McConfig,
     pub(crate) clients: HashMap<String, S3Client>,
 }
@@ -181,6 +186,9 @@ impl App {
             download_handle: None,
             download_started_at: None,
             preview: preview::PreviewState::new(),
+            bucket_input_active: false,
+            bucket_input: String::new(),
+            bucket_input_remote: None,
             config,
             clients: HashMap::new(),
         }

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -197,17 +197,24 @@ impl App {
             }
             Err(e) => {
                 let err_str = format!("{}", e);
-                let is_permission = err_str.contains("Access Denied")
-                    || err_str.contains("AccessDenied")
+                let is_access_error = err_str.contains("AccessDenied")
+                    || err_str.contains("Access Denied")
                     || err_str.contains("Forbidden")
-                    || err_str.contains("403");
-                if is_permission {
+                    || err_str.contains("403")
+                    || err_str.contains("Unauthorized")
+                    || err_str.contains("AllAccessDisabled")
+                    || err_str.contains("not authorized");
+                if is_access_error {
                     self.show_bucket_input(alias);
                     self.error = Some(
                         "ListBuckets denied — enter a bucket name manually".to_string(),
                     );
                 } else {
-                    self.error = Some(format!("Failed to list buckets: {}", e));
+                    self.show_bucket_input(alias);
+                    self.error = Some(format!(
+                        "Failed to list buckets: {} — enter a bucket name manually",
+                        e
+                    ));
                 }
             }
         }

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -196,9 +196,60 @@ impl App {
                 self.pane = Pane::Browser;
             }
             Err(e) => {
-                self.error = Some(format!("Failed to list buckets: {}", e));
+                let err_str = format!("{}", e);
+                let is_permission = err_str.contains("Access Denied")
+                    || err_str.contains("AccessDenied")
+                    || err_str.contains("Forbidden")
+                    || err_str.contains("403");
+                if is_permission {
+                    self.show_bucket_input(alias);
+                    self.error = Some(
+                        "ListBuckets denied — enter a bucket name manually".to_string(),
+                    );
+                } else {
+                    self.error = Some(format!("Failed to list buckets: {}", e));
+                }
             }
         }
+    }
+
+    pub(crate) fn show_bucket_input(&mut self, alias: &str) {
+        self.bucket_input_active = true;
+        self.bucket_input.clear();
+        self.bucket_input_remote = Some(alias.to_string());
+        self.location = Location::BucketList {
+            remote: alias.to_string(),
+        };
+        self.entries.clear();
+        self.browser_state.select(None);
+        self.pane = Pane::Browser;
+    }
+
+    pub async fn submit_bucket_input(&mut self) {
+        let bucket = self.bucket_input.trim().to_string();
+        if bucket.is_empty() {
+            return;
+        }
+        let remote = match self.bucket_input_remote.clone() {
+            Some(r) => r,
+            None => return,
+        };
+        self.bucket_input_active = false;
+        self.bucket_input.clear();
+        self.bucket_input_remote = None;
+        self.error = None;
+        self.enter_bucket(&remote, &bucket).await;
+    }
+
+    pub fn cancel_bucket_input(&mut self) {
+        self.bucket_input_active = false;
+        self.bucket_input.clear();
+        self.bucket_input_remote = None;
+        self.error = None;
+        self.location = Location::RemoteList;
+        self.entries.clear();
+        self.browser_state.select(None);
+        self.pane = Pane::Remotes;
     }
 
     pub(crate) async fn enter_bucket(&mut self, remote: &str, bucket: &str) {

--- a/src/s3_client.rs
+++ b/src/s3_client.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 
 use anyhow::Result;
 use aws_sdk_s3::config::{BehaviorVersion, Credentials, Region};
+use aws_sdk_s3::error::ProvideErrorMetadata;
 use aws_sdk_s3::types::{Delete, ObjectIdentifier};
 use aws_sdk_s3::Client;
 use tokio::sync::{mpsc, Semaphore};
@@ -93,7 +94,11 @@ impl S3Client {
     }
 
     pub async fn list_buckets(&self) -> Result<Vec<BucketInfo>> {
-        let output = self.client.list_buckets().send().await?;
+        let output = self.client.list_buckets().send().await.map_err(|e| {
+            let code = e.code().unwrap_or("Unknown");
+            let msg = e.message().unwrap_or("unknown error");
+            anyhow::anyhow!("[{}] {}", code, msg)
+        })?;
         let buckets = output
             .buckets()
             .iter()

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,7 +10,7 @@ use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use crossterm::execute;
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 
-use crate::app::{App, Pane};
+use crate::app::{App, Location, Pane};
 
 pub async fn run(app: &mut App) -> anyhow::Result<()> {
     terminal::enable_raw_mode()?;
@@ -48,7 +48,20 @@ async fn event_loop(
                     continue;
                 }
 
-                if app.confirm_delete.is_some() {
+                if app.bucket_input_active {
+                    // ── Bucket name input mode ──
+                    match key.code {
+                        KeyCode::Esc => app.cancel_bucket_input(),
+                        KeyCode::Enter => app.submit_bucket_input().await,
+                        KeyCode::Backspace => {
+                            app.bucket_input.pop();
+                        }
+                        KeyCode::Char(c) => {
+                            app.bucket_input.push(c);
+                        }
+                        _ => {}
+                    }
+                } else if app.confirm_delete.is_some() {
                     // ── Delete confirmation ──
                     match key.code {
                         KeyCode::Tab => app.toggle_delete_confirm(),
@@ -208,6 +221,13 @@ async fn event_loop(
                         KeyCode::Char('r') => app.refresh().await,
                         KeyCode::Tab => app.switch_pane(),
                         KeyCode::Char('p') => app.request_preview(),
+                        KeyCode::Char('i') => {
+                            // Open manual bucket input when on bucket list
+                            if let Location::BucketList { ref remote } = app.location {
+                                let remote = remote.clone();
+                                app.show_bucket_input(&remote);
+                            }
+                        }
                         KeyCode::Char('?') => app.show_help = true,
                         KeyCode::Esc => {
                             app.error = None;

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -71,11 +71,50 @@ pub fn render_confirm_delete(frame: &mut Frame, app: &App) {
     frame.render_widget(Paragraph::new(lines).block(block), popup);
 }
 
+pub fn render_bucket_input(frame: &mut Frame, app: &App) {
+    let area = frame.area();
+    let width = 54u16.min(area.width.saturating_sub(4));
+    let height = 7u16;
+    let x = (area.width.saturating_sub(width)) / 2;
+    let y = (area.height.saturating_sub(height)) / 2;
+    let popup = ratatui::layout::Rect::new(x, y, width, height);
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Bucket listing not permitted.",
+            Style::default().fg(Color::Yellow),
+        )),
+        Line::from(vec![
+            Span::styled("  Name: ", Style::default().fg(Color::Cyan)),
+            Span::raw(&app.bucket_input),
+            Span::styled("_", Style::default().fg(Color::DarkGray)),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Enter confirm  Esc cancel",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+
+    let block = Block::bordered()
+        .title(" Enter Bucket Name ")
+        .title_style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )
+        .border_style(Style::default().fg(Color::Cyan));
+
+    frame.render_widget(Clear, popup);
+    frame.render_widget(Paragraph::new(lines).block(block), popup);
+}
+
 pub fn render_help(frame: &mut Frame) {
     let area = frame.area();
 
     let width = 52u16.min(area.width.saturating_sub(4));
-    let height = 30u16.min(area.height.saturating_sub(2));
+    let height = 31u16.min(area.height.saturating_sub(2));
     let x = (area.width.saturating_sub(width)) / 2;
     let y = (area.height.saturating_sub(height)) / 2;
     let popup = ratatui::layout::Rect::new(x, y, width, height);
@@ -107,6 +146,7 @@ pub fn render_help(frame: &mut Frame) {
         Line::from(vec![key("r"), desc("Refresh current view")]),
         Line::from(vec![key("Shift+C"), desc("Download (copy) to local")]),
         Line::from(vec![key("d / Cmd+Bksp"), desc("Delete file or directory")]),
+        Line::from(vec![key("i"), desc("Enter bucket name manually")]),
         Line::from(vec![key("p"), desc("Preview file (text/image/video)")]),
         Line::from(vec![key("Esc"), desc("Dismiss error / metadata")]),
         Line::from(vec![key("q"), desc("Quit")]),

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -97,6 +97,10 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         status::render_status_bar(frame, app, outer[3]);
     }
 
+    if app.bucket_input_active {
+        popups::render_bucket_input(frame, app);
+    }
+
     if app.confirm_delete.is_some() {
         popups::render_confirm_delete(frame, app);
     }


### PR DESCRIPTION
## Summary
- When an S3 endpoint denies `ListBuckets` permission (AccessDenied/403), a text input popup now appears instead of just an error, allowing the user to type a bucket name manually
- Added `i` keybinding on the bucket list view to open the manual bucket input at any time
- Updated help popup with the new keybinding

Closes #2

## Test plan
- [x] Connect to an S3 endpoint that denies ListBuckets — verify the bucket input popup appears
- [x] Type a valid bucket name and press Enter — verify navigation into the bucket works
- [ ] Press Esc on the popup — verify it cancels and returns to remotes
- [ ] On a normal bucket list, press `i` — verify the manual input popup opens
- [ ] Press `?` — verify the help popup shows the new `i` keybinding

🤖 Generated with [Claude Code](https://claude.com/claude-code)