### PR TITLE
[codex] Add remote MCAP preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +412,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+
+[[package]]
+name = "binrw"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1faf7031c34c71da53eec4e070cf90c3b825729e21ca3aab51b20da4a1d1d9"
+dependencies = [
+ "array-init",
+ "binrw_derive",
+ "bytemuck",
+]
+
+[[package]]
+name = "binrw_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c5eb3446e2f5ea7fa9a6f2cb594648c73bf2dbc60eccf3b2fa41834e5449150"
+dependencies = [
+ "either",
+ "owo-colors",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +461,18 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -642,12 +690,35 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -660,7 +731,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -669,9 +751,9 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -743,7 +825,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -794,6 +876,27 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "enumset"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c4174b41e75c8f7306110b2c51996a293b8d1d850edd529011841d9fede7d"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1037,6 +1140,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1364,11 +1473,11 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1486,6 +1595,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
+dependencies = [
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "mcap"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43908ab970f3a880b02834055a1e04221a3056f442a65ae9111f63e550e7daa5"
+dependencies = [
+ "bimap",
+ "binrw",
+ "byteorder",
+ "crc32fast",
+ "enumset",
+ "log",
+ "lz4",
+ "num_cpus",
+ "paste",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "zstd",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,6 +1692,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1652,6 +1810,12 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "p256"
@@ -1833,7 +1997,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2014,7 +2178,7 @@ checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "s3-like-yazi"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -2023,6 +2187,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "humansize",
+ "mcap",
  "ratatui",
  "regex",
  "serde",
@@ -2125,7 +2290,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2295,7 +2460,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2303,6 +2468,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2323,7 +2499,16 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -2332,7 +2517,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2343,7 +2539,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2410,7 +2606,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2487,7 +2683,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2659,7 +2855,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -2951,7 +3147,7 @@ dependencies = [
  "log",
  "os_pipe",
  "rustix 1.1.3",
- "thiserror",
+ "thiserror 2.0.18",
  "tree_magic_mini",
  "wayland-backend",
  "wayland-client",
@@ -3007,7 +3203,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -3028,7 +3224,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -3068,7 +3264,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3076,3 +3272,31 @@ name = "zmij"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3-like-yazi"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 description = "A blazing-fast terminal file manager for S3-compatible storage, inspired by Yazi"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ humansize = "2"
 anyhow = "1"
 regex = "1"
 arboard = { version = "3", default-features = false, features = ["wayland-data-control"] }
+mcap = "0.24"
 
 [profile.release]
 strip = true

--- a/docs/knowledgebase.md
+++ b/docs/knowledgebase.md
@@ -1,0 +1,277 @@
+# s3-like-yazi Knowledgebase
+
+This document captures the current implementation of `s3-like-yazi` for future
+contributors and coding agents. Treat the source code as the source of truth;
+`research.md` is historical planning material and may describe older design
+ideas that no longer match the app.
+
+## Project Purpose
+
+`s3-like-yazi` is a Rust terminal file manager for S3-compatible storage such as
+MinIO, AWS S3, Backblaze B2, and Wasabi. It uses Ratatui and Crossterm for the
+terminal interface, the AWS S3 SDK for object storage operations, and Tokio for
+background tasks.
+
+The app starts from existing MinIO client credentials, shows configured remotes,
+lets the user browse buckets and object prefixes, and supports search, metadata
+inspection, recursive delete, local downloads, manual bucket entry, presigned
+download URLs, and file previews.
+
+## Build And Verification
+
+Common commands:
+
+```bash
+cargo test --no-run
+cargo build
+cargo build --release
+```
+
+There are currently no dedicated unit or integration tests. `cargo test
+--no-run` is the baseline compile verification command and should succeed before
+and after documentation or code changes.
+
+Runtime requirements:
+
+- Rust 1.85 or newer, because the crate uses edition 2024.
+- A MinIO client config at `~/.mc/config.json` or `~/.mcli/config.json`.
+- `ffplay` from ffmpeg for image and video previews. Text previews work without
+  ffmpeg.
+
+## Architecture Map
+
+Top-level flow:
+
+- `src/main.rs` loads the MinIO config, constructs `App`, and enters `ui::run`.
+- `src/credentials.rs` parses `mc`/`mcli` config aliases, including optional
+  per-alias region.
+- `src/app/mod.rs` owns the central state machine: active pane, navigation
+  location, entries, metadata, search state, indexing state, download state,
+  preview state, manual bucket input, cached S3 clients, and navigation history.
+- `src/s3_client.rs` wraps AWS SDK S3 calls for buckets, objects, indexing,
+  deletion, metadata, byte ranges, presigned URLs, and downloads.
+- `src/ui/mod.rs` owns terminal setup, the event loop, key dispatch, background
+  channel draining, and terminal cleanup.
+- `src/ui/render.rs`, `src/ui/status.rs`, `src/ui/popups.rs`, and
+  `src/ui/local_fs.rs` render the main panes, status/search bars, dialogs, text
+  preview, metadata, and local download chooser.
+
+Feature modules:
+
+- Navigation: `src/app/navigation.rs` moves through remotes, buckets, prefixes,
+  metadata, refresh, back navigation, manual bucket entry, and presigned links.
+- Search: `src/app/search.rs` handles search mode, substring matching, glob
+  matching with `*` and `?`, regex matching with `/pattern/`, and jumping to a
+  selected object.
+- Background indexing: `src/app/indexing.rs` starts and drains a task that
+  streams every object in the active bucket into the search pool.
+- Delete: `src/app/delete.rs` confirms and deletes files or recursively deletes
+  all objects under a prefix. Bucket deletion is intentionally unsupported.
+- Download: `src/app/download.rs` enters local save mode, allows rename, starts
+  object or prefix downloads, and drains progress updates.
+- Local filesystem: `src/app/local_fs.rs` lists local directories for download
+  destinations and hides dotfiles.
+- Preview: `src/app/preview.rs` detects preview kind by content type or file
+  extension. Text previews download a byte range inline; image/video previews
+  generate a presigned URL and open `ffplay`.
+
+## Data And Control Flow
+
+Startup:
+
+1. `main` calls `McConfig::load`.
+2. Config loading checks `~/.mc/config.json` first, then
+   `~/.mcli/config.json`.
+3. `App::new` sorts aliases into the remotes pane and selects the first remote
+   when present.
+4. `ui::run` enters raw mode, switches to the alternate screen, runs the event
+   loop, then restores the terminal on exit.
+
+Remote and bucket browsing:
+
+1. Selecting a remote lazily creates an `S3Client` from that alias config.
+2. `list_buckets` populates the browser pane with bucket entries.
+3. If bucket listing is denied or fails, the app opens manual bucket input so
+   users can type a known bucket name.
+4. Selecting a bucket or directory prefix calls `list_objects` with delimiter
+   `/`, producing directory entries from common prefixes and file entries from
+   object contents.
+5. Navigation history remembers cursor positions when moving into buckets and
+   prefixes, then restores them when going back.
+
+S3 client behavior:
+
+- Clients use `aws-sdk-s3` with an explicit endpoint URL and
+  `force_path_style(true)`, which is important for many S3-compatible services.
+- The default region is `us-east-1` when the config does not provide one.
+- On `AuthorizationHeaderMalformed` errors containing `expecting '<region>'`,
+  the app recreates the client with the hinted region and retries bucket
+  listing once.
+
+Search and indexing:
+
+- Entering a bucket or prefix starts background indexing for the whole bucket.
+- The indexing task pages through `ListObjectsV2` without a delimiter and sends
+  batches over a Tokio channel.
+- The event loop calls `drain_index` every tick, extending `search_pool` and
+  updating active search results as batches arrive.
+- Search within an indexed bucket matches against full object keys. Without an
+  index context, it filters the current saved entry list.
+- Search supports case-insensitive substring matching, glob patterns containing
+  `*` or `?`, and regex mode when the query is wrapped as `/pattern/`.
+- Starting indexing for a different bucket aborts the previous indexing task.
+
+Metadata and presigned URLs:
+
+- Pressing Enter on a file calls `head_object` and renders size, content type,
+  modified time, ETag, optional version/storage fields, and user metadata.
+- Pressing `Shift+L` on a file creates a one-hour presigned GET URL and attempts
+  to copy it to the clipboard via `arboard`. If clipboard access fails, the URL
+  is still shown in the metadata panel.
+
+Downloads:
+
+- Pressing `Shift+C` on an object enters download mode and shows a local
+  filesystem pane.
+- The local pane starts at the process current directory, hides dotfiles, sorts
+  directories first, and supports entering directories or going to the parent.
+- Pressing `n` allows a custom save name. Pressing `c` confirms the download.
+- File downloads stream one object to disk and report byte progress.
+- Directory downloads list all keys under the selected prefix, then download
+  them concurrently with a fixed concurrency of four.
+- Downloads create parent directories as needed and report aggregate progress
+  through the status bar.
+
+Deletion:
+
+- Pressing `d` or Cmd+Backspace on an object opens a confirmation dialog.
+- File deletion uses `DeleteObject`.
+- Directory deletion lists all objects under the selected prefix and deletes in
+  `DeleteObjects` batches of up to 1000 keys.
+- After deletion, the visible entries and search pool are pruned and selection
+  is repaired.
+- Bucket deletion is not supported.
+
+Previews:
+
+- Pressing `p` previews the selected file.
+- Text-like files fetch at most 512 KiB with a range request and render inline.
+- JSON text is pretty-printed when possible.
+- Text preview mode has its own scroll keys and can be closed with `q` or Esc.
+- Image and video previews generate a presigned URL and spawn `ffplay`.
+- On macOS, Linux, and Windows the preview module makes a best-effort attempt to
+  focus the `ffplay` window.
+
+## Keybindings
+
+Normal mode:
+
+| Key | Action |
+| --- | --- |
+| `q` | Quit |
+| `j` / Down | Move cursor down |
+| `k` / Up | Move cursor up |
+| `l` / Enter | Open remote, bucket, directory, or fetch file metadata |
+| `h` / Backspace | Go back |
+| Tab | Switch panes |
+| `/` or Ctrl+P | Start search |
+| `r` | Refresh current location |
+| `Shift+C` | Enter download mode for the selected object or prefix |
+| `d` or Cmd+Backspace | Request delete for selected object or prefix |
+| `Shift+L` | Generate and copy a one-hour presigned download URL |
+| `i` | Enter a bucket name manually from a bucket-list location |
+| `p` | Preview selected file |
+| `?` | Show help |
+| Esc | Dismiss error, metadata, URL, status, progress, or preview |
+
+Search mode:
+
+| Key | Action |
+| --- | --- |
+| Text input | Filter results |
+| Backspace | Remove one query character |
+| Up / Down | Move through matches |
+| Enter | Jump to selected match |
+| Esc | Cancel search and restore previous view |
+
+Search syntax:
+
+- Plain text performs case-insensitive substring matching.
+- Queries containing `*` or `?` use glob matching.
+- `/pattern/` uses case-insensitive regex matching.
+
+Download mode:
+
+| Key | Action |
+| --- | --- |
+| `j` / Down | Move in active pane |
+| `k` / Up | Move in active pane |
+| `l` / Enter | Open selected local directory, or select remote item when browser pane is active |
+| `h` / Backspace | Go to parent local directory, or go back remotely when browser pane is active |
+| Tab | Switch between remotes, browser, and local filesystem panes |
+| `c` | Confirm download to current local path |
+| `n` | Rename before saving |
+| Esc | Cancel download mode |
+
+Rename input:
+
+| Key | Action |
+| --- | --- |
+| Text input | Append to target name |
+| Backspace | Remove one character |
+| Enter | Accept custom name |
+| Esc | Cancel rename |
+
+Manual bucket input:
+
+| Key | Action |
+| --- | --- |
+| Text input | Edit bucket name |
+| Backspace | Remove one character |
+| Enter | Open typed bucket |
+| Esc | Cancel and return to remotes |
+
+Delete confirmation:
+
+| Key | Action |
+| --- | --- |
+| Tab | Toggle No/Yes |
+| Enter | Confirm selected option |
+| Esc | Cancel |
+
+Text preview mode:
+
+| Key | Action |
+| --- | --- |
+| `j` / Down | Scroll down one line |
+| `k` / Up | Scroll up one line |
+| Ctrl+D | Scroll down 20 lines |
+| Ctrl+U | Scroll up 20 lines |
+| `g` | Go to top |
+| `G` | Go to bottom |
+| `q` or Esc | Close preview |
+
+## Implementation Notes And Gotchas
+
+- Keep `research.md` as historical context only. Prefer current source files
+  when documenting or changing behavior.
+- README currently understates some implemented features, especially downloads,
+  manual bucket entry, previews, presigned URLs, and glob/regex search.
+- `Cargo.lock` and `.DS_Store` may already be dirty in local worktrees; avoid
+  modifying or reverting them unless explicitly requested.
+- The app intentionally uses path-style S3 addressing for compatibility with
+  MinIO and other S3-compatible endpoints.
+- Long-running background work communicates with the UI through Tokio channels
+  and is drained from the main event loop. Avoid blocking the event loop.
+- Starting a new bucket index aborts the previous index task and clears the
+  search pool.
+- Preview image/video support depends on an external `ffplay` executable rather
+  than embedding media in the TUI.
+- Text preview downloads only the first 512 KiB, so it is a preview, not a full
+  file viewer.
+- Recursive delete and directory download both operate by object-key prefix.
+  They do not depend on real directory objects existing in S3.
+- Local download destination browsing skips hidden entries by name.
+- There are no current automated behavioral tests. For risky code changes,
+  prefer adding focused unit tests around pure logic such as search matching,
+  parent-prefix navigation, region hint parsing, and state transitions.

--- a/src/app/preview.rs
+++ b/src/app/preview.rs
@@ -7,6 +7,11 @@ use super::{App, Entry, Location};
 pub enum PreviewMsg {
     /// Text content ready to display inline.
     TextReady(String),
+    /// Progress while reading a remote MCAP summary/index.
+    MCapProgress {
+        bytes_read: u64,
+        total_bytes: Option<u64>,
+    },
     /// Error during preview.
     Error(String),
 }
@@ -16,6 +21,13 @@ pub enum PreviewKind {
     Image,
     Video,
     Text,
+    MCap,
+}
+
+pub struct PreviewProgress {
+    pub label: String,
+    pub bytes_read: u64,
+    pub total_bytes: Option<u64>,
 }
 
 /// Current state of the preview system.
@@ -32,6 +44,8 @@ pub struct PreviewState {
     pub scroll_offset: usize,
     /// Total line count of text_content (cached).
     pub line_count: usize,
+    /// Progress for remote range-based preview loading.
+    pub progress: Option<PreviewProgress>,
     /// Background task channel.
     pub rx: Option<mpsc::Receiver<PreviewMsg>>,
     /// Background task handle.
@@ -50,6 +64,7 @@ impl PreviewState {
             error: None,
             scroll_offset: 0,
             line_count: 0,
+            progress: None,
             rx: None,
             handle: None,
         }
@@ -62,6 +77,7 @@ impl PreviewState {
         self.error = None;
         self.scroll_offset = 0;
         self.line_count = 0;
+        self.progress = None;
         self.rx = None;
         if let Some(h) = self.handle.take() {
             h.abort();
@@ -74,7 +90,8 @@ impl PreviewState {
 
     pub fn scroll_down(&mut self, lines: usize) {
         if self.line_count > 0 {
-            self.scroll_offset = (self.scroll_offset + lines).min(self.line_count.saturating_sub(1));
+            self.scroll_offset =
+                (self.scroll_offset + lines).min(self.line_count.saturating_sub(1));
         }
     }
 }
@@ -116,13 +133,13 @@ fn extension_to_kind(key: &str) -> Option<PreviewKind> {
         "mp4" | "mkv" | "avi" | "mov" | "webm" | "flv" | "wmv" | "m4v" | "3gp" => {
             Some(PreviewKind::Video)
         }
-        "txt" | "md" | "markdown" | "json" | "yaml" | "yml" | "toml" | "xml" | "csv"
-        | "tsv" | "log" | "ini" | "cfg" | "conf" | "env" | "sh" | "bash" | "zsh"
-        | "fish" | "py" | "rs" | "go" | "js" | "ts" | "jsx" | "tsx" | "html" | "htm"
-        | "css" | "scss" | "less" | "sql" | "rb" | "lua" | "c" | "cpp" | "h" | "hpp"
-        | "java" | "kt" | "swift" | "r" | "R" | "pl" | "pm" | "php" | "ex" | "exs"
-        | "erl" | "hs" | "ml" | "tf" | "hcl" | "dockerfile" | "makefile" | "cmake"
-        | "gitignore" | "dockerignore" | "editorconfig" | "properties" => {
+        "mcap" | "svo2" => Some(PreviewKind::MCap),
+        "txt" | "md" | "markdown" | "json" | "yaml" | "yml" | "toml" | "xml" | "csv" | "tsv"
+        | "log" | "ini" | "cfg" | "conf" | "env" | "sh" | "bash" | "zsh" | "fish" | "py" | "rs"
+        | "go" | "js" | "ts" | "jsx" | "tsx" | "html" | "htm" | "css" | "scss" | "less" | "sql"
+        | "rb" | "lua" | "c" | "cpp" | "h" | "hpp" | "java" | "kt" | "swift" | "r" | "R" | "pl"
+        | "pm" | "php" | "ex" | "exs" | "erl" | "hs" | "ml" | "tf" | "hcl" | "dockerfile"
+        | "makefile" | "cmake" | "gitignore" | "dockerignore" | "editorconfig" | "properties" => {
             Some(PreviewKind::Text)
         }
         _ => None,
@@ -132,7 +149,10 @@ fn extension_to_kind(key: &str) -> Option<PreviewKind> {
 impl App {
     /// Drain preview messages from background task.
     pub fn drain_preview(&mut self) {
-        let is_json = self.preview.current_key.as_deref()
+        let is_json = self
+            .preview
+            .current_key
+            .as_deref()
             .and_then(|k| k.rsplit('.').next())
             .map(|ext| ext.eq_ignore_ascii_case("json"))
             .unwrap_or(false);
@@ -145,6 +165,7 @@ impl App {
             match msg {
                 PreviewMsg::TextReady(text) => {
                     self.preview.loading = false;
+                    self.preview.progress = None;
                     let text = if is_json {
                         try_pretty_json(&text)
                     } else {
@@ -153,11 +174,39 @@ impl App {
                     self.preview.line_count = text.lines().count();
                     self.preview.scroll_offset = 0;
                     self.preview.text_content = Some(text);
+                    self.status_message = Some("Preview ready".to_string());
+                }
+                PreviewMsg::MCapProgress {
+                    bytes_read,
+                    total_bytes,
+                } => {
+                    self.preview.progress = Some(PreviewProgress {
+                        label: "Reading MCAP index".to_string(),
+                        bytes_read,
+                        total_bytes,
+                    });
                 }
                 PreviewMsg::Error(e) => {
                     self.preview.loading = false;
+                    self.preview.progress = None;
                     self.preview.error = Some(e);
+                    self.status_message = None;
                 }
+            }
+        }
+    }
+
+    pub fn copy_preview_to_clipboard(&mut self) {
+        let Some(text) = self.preview.text_content.as_ref() else {
+            return;
+        };
+
+        match arboard::Clipboard::new().and_then(|mut cb| cb.set_text(text.clone())) {
+            Ok(()) => {
+                self.status_message = Some("Preview copied to clipboard".to_string());
+            }
+            Err(e) => {
+                self.status_message = Some(format!("Clipboard copy failed: {}", e));
             }
         }
     }
@@ -223,6 +272,29 @@ impl App {
                     }
                 });
             }
+            PreviewKind::MCap => {
+                self.preview.loading = true;
+                self.preview.progress = Some(PreviewProgress {
+                    label: "Reading MCAP index".to_string(),
+                    bytes_read: 0,
+                    total_bytes: None,
+                });
+                self.status_message = Some("Reading MCAP index from remote...".into());
+
+                let size = size.max(0) as u64;
+                let handle = tokio::spawn(async move {
+                    let result = read_remote_mcap_summary(&client, &bucket, &key_clone, size, &tx)
+                        .await
+                        .map(format_mcap_summary);
+
+                    let msg = match result {
+                        Ok(text) => PreviewMsg::TextReady(text),
+                        Err(e) => PreviewMsg::Error(e.to_string()),
+                    };
+                    let _ = tx.send(msg).await;
+                });
+                self.preview.handle = Some(handle);
+            }
             PreviewKind::Image | PreviewKind::Video => {
                 let label = match kind {
                     PreviewKind::Image => "image",
@@ -241,10 +313,12 @@ impl App {
                     match client.presign_get_object(&bucket, &key_clone).await {
                         Ok(url) => {
                             let mut args = vec![
-                                "-v".to_string(), "warning".to_string(),
+                                "-v".to_string(),
+                                "warning".to_string(),
                                 "-autoexit".to_string(),
                                 "-alwaysontop".to_string(),
-                                "-window_title".to_string(), key_clone.clone(),
+                                "-window_title".to_string(),
+                                key_clone.clone(),
                             ];
                             args.extend(extra_args);
                             args.push(url);
@@ -262,7 +336,8 @@ impl App {
                                     focus_window().await;
                                     let _ = tokio::task::spawn_blocking(move || {
                                         child.wait_with_output()
-                                    }).await;
+                                    })
+                                    .await;
                                 }
                                 Err(_) => {
                                     let _ = tx
@@ -297,10 +372,7 @@ impl App {
                     ..
                 } = self.location
                 {
-                    let ct = self
-                        .metadata
-                        .as_ref()
-                        .and_then(|m| m.content_type.clone());
+                    let ct = self.metadata.as_ref().and_then(|m| m.content_type.clone());
                     Some((
                         remote.clone(),
                         bucket.clone(),
@@ -321,6 +393,269 @@ impl App {
         let temp_dir = std::env::temp_dir().join("s3-like-yazi-preview");
         let _ = std::fs::remove_dir_all(temp_dir);
     }
+}
+
+struct RangeCache {
+    start: u64,
+    bytes: Vec<u8>,
+}
+
+impl RangeCache {
+    fn contains(&self, start: u64, end: u64) -> bool {
+        let cache_end = self.start.saturating_add(self.bytes.len() as u64);
+        start >= self.start && end <= cache_end
+    }
+
+    fn slice(&self, start: u64, end: u64) -> anyhow::Result<&[u8]> {
+        if !self.contains(start, end) {
+            anyhow::bail!("requested range is outside the MCAP preview cache");
+        }
+
+        let local_start = (start - self.start) as usize;
+        let local_end = (end - self.start) as usize;
+        Ok(&self.bytes[local_start..local_end])
+    }
+}
+
+async fn read_remote_mcap_summary(
+    client: &crate::s3_client::S3Client,
+    bucket: &str,
+    key: &str,
+    size: u64,
+    tx: &mpsc::Sender<PreviewMsg>,
+) -> anyhow::Result<mcap::Summary> {
+    if size == 0 {
+        anyhow::bail!("Object is empty");
+    }
+
+    let mut reader = mcap::sans_io::SummaryReader::new_with_options(
+        mcap::sans_io::SummaryReaderOptions::default().with_file_size(size),
+    );
+    let mut cache: Option<RangeCache> = None;
+    let mut pos = 0u64;
+    let mut bytes_read = 0u64;
+    let mut total_needed: Option<u64> = None;
+
+    while let Some(event) = reader.next_event() {
+        match event? {
+            mcap::sans_io::SummaryReadEvent::ReadRequest(need) => {
+                let end = pos
+                    .checked_add(need as u64)
+                    .ok_or_else(|| anyhow::anyhow!("MCAP range overflow"))?;
+                let was_cached = cache.as_ref().is_some_and(|cache| cache.contains(pos, end));
+                let bytes = if was_cached {
+                    cache
+                        .as_ref()
+                        .expect("cache checked above")
+                        .slice(pos, end)?
+                        .to_vec()
+                } else {
+                    client.get_object_range(bucket, key, pos, end).await?
+                };
+                let read = bytes.len().min(need);
+                reader.insert(need)[..read].copy_from_slice(&bytes[..read]);
+                reader.notify_read(read);
+                pos = pos.saturating_add(read as u64);
+
+                if !was_cached {
+                    bytes_read = bytes_read.saturating_add(read as u64);
+                    send_mcap_progress(tx, bytes_read, total_needed);
+                }
+            }
+            mcap::sans_io::SummaryReadEvent::SeekRequest(to) => {
+                let next = seek_position(size, pos, to)?;
+                reader.notify_seeked(next);
+                pos = next;
+
+                if pos < size && cache.as_ref().is_none_or(|cache| !cache.contains(pos, pos)) {
+                    let range_len = size - pos;
+                    total_needed = Some(bytes_read.saturating_add(range_len));
+                    send_mcap_progress(tx, bytes_read, total_needed);
+
+                    let bytes = client.get_object_range(bucket, key, pos, size).await?;
+                    let loaded = bytes.len() as u64;
+                    cache = Some(RangeCache { start: pos, bytes });
+                    bytes_read = bytes_read.saturating_add(loaded);
+                    send_mcap_progress(tx, bytes_read, total_needed);
+                }
+            }
+        }
+    }
+
+    reader
+        .finish()
+        .ok_or_else(|| anyhow::anyhow!("MCAP file has no summary/index section"))
+}
+
+fn send_mcap_progress(tx: &mpsc::Sender<PreviewMsg>, bytes_read: u64, total_bytes: Option<u64>) {
+    let _ = tx.try_send(PreviewMsg::MCapProgress {
+        bytes_read,
+        total_bytes,
+    });
+}
+
+fn seek_position(size: u64, current: u64, seek: std::io::SeekFrom) -> anyhow::Result<u64> {
+    let pos = match seek {
+        std::io::SeekFrom::Start(pos) => pos as i128,
+        std::io::SeekFrom::End(delta) => size as i128 + delta as i128,
+        std::io::SeekFrom::Current(delta) => current as i128 + delta as i128,
+    };
+    if pos < 0 || pos > size as i128 {
+        anyhow::bail!("MCAP reader requested invalid seek position {}", pos);
+    }
+    Ok(pos as u64)
+}
+
+fn format_mcap_time(ns: u64) -> String {
+    if ns == 0 {
+        return "-".to_string();
+    }
+
+    let secs = (ns / 1_000_000_000) as i64;
+    let nanos = (ns % 1_000_000_000) as u32;
+    chrono::DateTime::from_timestamp(secs, nanos)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M:%S%.3f UTC").to_string())
+        .unwrap_or_else(|| ns.to_string())
+}
+
+fn format_duration_ns(start: u64, end: u64) -> String {
+    if end <= start {
+        return "-".to_string();
+    }
+
+    let secs = (end - start) as f64 / 1_000_000_000.0;
+    if secs >= 3600.0 {
+        format!("{:.2} h", secs / 3600.0)
+    } else if secs >= 60.0 {
+        format!("{:.2} min", secs / 60.0)
+    } else {
+        format!("{:.3} s", secs)
+    }
+}
+
+fn format_mcap_summary(summary: mcap::Summary) -> String {
+    let mut lines = Vec::new();
+
+    lines.push("MCAP Summary".to_string());
+    lines.push(String::new());
+
+    if let Some(stats) = &summary.stats {
+        lines.push(format!("Messages:        {}", stats.message_count));
+        lines.push(format!("Schemas:         {}", stats.schema_count));
+        lines.push(format!("Channels:        {}", stats.channel_count));
+        lines.push(format!("Chunks:          {}", stats.chunk_count));
+        lines.push(format!("Attachments:     {}", stats.attachment_count));
+        lines.push(format!("Metadata:        {}", stats.metadata_count));
+        lines.push(format!(
+            "Start time:      {}",
+            format_mcap_time(stats.message_start_time)
+        ));
+        lines.push(format!(
+            "End time:        {}",
+            format_mcap_time(stats.message_end_time)
+        ));
+        lines.push(format!(
+            "Duration:        {}",
+            format_duration_ns(stats.message_start_time, stats.message_end_time)
+        ));
+    } else {
+        lines.push("Statistics:      not present".to_string());
+        lines.push(format!("Schemas:         {}", summary.schemas.len()));
+        lines.push(format!("Channels:        {}", summary.channels.len()));
+        lines.push(format!("Chunks:          {}", summary.chunk_indexes.len()));
+        lines.push(format!(
+            "Attachments:     {}",
+            summary.attachment_indexes.len()
+        ));
+        lines.push(format!(
+            "Metadata:        {}",
+            summary.metadata_indexes.len()
+        ));
+    }
+
+    lines.push(String::new());
+    lines.push("Channels".to_string());
+    let mut channels: Vec<_> = summary.channels.values().collect();
+    channels.sort_by_key(|channel| channel.id);
+    if channels.is_empty() {
+        lines.push("  none".to_string());
+    } else {
+        for channel in channels.iter().take(200) {
+            let schema_name = channel
+                .schema
+                .as_ref()
+                .map(|schema| schema.name.as_str())
+                .unwrap_or("-");
+            lines.push(format!(
+                "  {:>4}  {}  [{}]  schema: {}",
+                channel.id, channel.topic, channel.message_encoding, schema_name
+            ));
+        }
+        if channels.len() > 200 {
+            lines.push(format!("  ... {} more channels", channels.len() - 200));
+        }
+    }
+
+    if !summary.schemas.is_empty() {
+        lines.push(String::new());
+        lines.push("Schemas".to_string());
+        let mut schemas: Vec<_> = summary.schemas.values().collect();
+        schemas.sort_by_key(|schema| schema.id);
+        for schema in schemas.iter().take(100) {
+            lines.push(format!(
+                "  {:>4}  {}  [{}]  {}",
+                schema.id,
+                schema.name,
+                schema.encoding,
+                humansize::format_size(schema.data.len() as u64, humansize::BINARY)
+            ));
+        }
+        if schemas.len() > 100 {
+            lines.push(format!("  ... {} more schemas", schemas.len() - 100));
+        }
+    }
+
+    if let Some(stats) = &summary.stats {
+        if !stats.channel_message_counts.is_empty() {
+            lines.push(String::new());
+            lines.push("Message Counts By Channel".to_string());
+            for (channel_id, count) in &stats.channel_message_counts {
+                let topic = summary
+                    .channels
+                    .get(channel_id)
+                    .map(|channel| channel.topic.as_str())
+                    .unwrap_or("-");
+                lines.push(format!("  {:>4}  {:>12}  {}", channel_id, count, topic));
+            }
+        }
+    }
+
+    if !summary.attachment_indexes.is_empty() {
+        lines.push(String::new());
+        lines.push("Attachments".to_string());
+        for attachment in &summary.attachment_indexes {
+            lines.push(format!(
+                "  {}  [{}]  {}",
+                attachment.name,
+                attachment.media_type,
+                humansize::format_size(attachment.data_size, humansize::BINARY)
+            ));
+        }
+    }
+
+    if !summary.metadata_indexes.is_empty() {
+        lines.push(String::new());
+        lines.push("Metadata Records".to_string());
+        for metadata in &summary.metadata_indexes {
+            lines.push(format!(
+                "  {}  {}",
+                metadata.name,
+                humansize::format_size(metadata.length, humansize::BINARY)
+            ));
+        }
+    }
+
+    lines.join("\n")
 }
 
 /// Bring the ffplay window to front and give it keyboard focus.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -189,6 +189,7 @@ async fn event_loop(
                         KeyCode::Char('G') => {
                             app.preview.scroll_offset = app.preview.line_count.saturating_sub(1);
                         }
+                        KeyCode::Char('C') => app.copy_preview_to_clipboard(),
                         KeyCode::Char('q') | KeyCode::Esc => {
                             app.preview.clear();
                             app.status_message = None;

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -148,7 +148,7 @@ pub fn render_help(frame: &mut Frame) {
         Line::from(vec![key("d / Cmd+Bksp"), desc("Delete file or directory")]),
         Line::from(vec![key("Shift+L"), desc("Copy presigned URL (1h)")]),
         Line::from(vec![key("i"), desc("Enter bucket name manually")]),
-        Line::from(vec![key("p"), desc("Preview file (text/image/video)")]),
+        Line::from(vec![key("p"), desc("Preview file (text/image/video/MCAP)")]),
         Line::from(vec![key("Esc"), desc("Dismiss error / metadata")]),
         Line::from(vec![key("q"), desc("Quit")]),
         Line::from(""),

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -1,10 +1,10 @@
+use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{
     Block, Cell, HighlightSpacing, List, ListItem, Paragraph, Row, Table, Wrap,
 };
-use ratatui::Frame;
 
 use crate::app::{App, Entry, Pane};
 
@@ -13,16 +13,19 @@ use super::popups;
 use super::status;
 
 pub fn render(frame: &mut Frame, app: &mut App) {
-    let has_text_preview = app.preview.text_content.is_some()
-        || app.preview.loading
-        || app.preview.error.is_some();
+    let has_text_preview =
+        app.preview.text_content.is_some() || app.preview.loading || app.preview.error.is_some();
 
-    let meta_height = if has_text_preview { Constraint::Percentage(40) } else { Constraint::Length(7) };
+    let meta_height = if has_text_preview {
+        Constraint::Percentage(40)
+    } else {
+        Constraint::Length(7)
+    };
 
     let outer = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),  // Title bar
+            Constraint::Length(1), // Title bar
             Constraint::Min(8),    // Main content
             meta_height,           // Metadata or text preview panel
             Constraint::Length(1), // Status / search bar
@@ -68,7 +71,10 @@ pub fn render(frame: &mut Frame, app: &mut App) {
 
         local_fs::render_download_target(frame, app, meta_layout[0]);
         render_metadata(frame, app, meta_layout[1]);
-    } else if app.preview.text_content.is_some() || app.preview.loading || app.preview.error.is_some() {
+    } else if app.preview.text_content.is_some()
+        || app.preview.loading
+        || app.preview.error.is_some()
+    {
         // Text preview active: split main area into browser (top) and preview (bottom)
         let content = Layout::default()
             .direction(Direction::Horizontal)
@@ -152,7 +158,14 @@ fn render_browser(frame: &mut Frame, app: &mut App, area: ratatui::layout::Rect)
         .map(|entry| match entry {
             Entry::Bucket(b) => {
                 let date = b.creation_date.clone().unwrap_or_default();
-                ("B".into(), b.name.clone(), "bucket".into(), date, Color::Yellow, Color::White)
+                (
+                    "B".into(),
+                    b.name.clone(),
+                    "bucket".into(),
+                    date,
+                    Color::Yellow,
+                    Color::White,
+                )
             }
             Entry::Object(obj) if obj.is_dir => (
                 "D".into(),
@@ -165,7 +178,14 @@ fn render_browser(frame: &mut Frame, app: &mut App, area: ratatui::layout::Rect)
             Entry::Object(obj) => {
                 let size = humansize::format_size(obj.size as u64, humansize::BINARY);
                 let date = obj.last_modified.clone().unwrap_or_default();
-                (" ".into(), obj.display_name.clone(), size, date, Color::Reset, Color::White)
+                (
+                    " ".into(),
+                    obj.display_name.clone(),
+                    size,
+                    date,
+                    Color::Reset,
+                    Color::White,
+                )
             }
         })
         .collect();
@@ -175,7 +195,11 @@ fn render_browser(frame: &mut Frame, app: &mut App, area: ratatui::layout::Rect)
     let rows: Vec<Row> = row_data
         .iter()
         .map(|(icon, name, size, date, icon_color, name_color)| {
-            let size_color = if icon.trim().is_empty() { Color::Green } else { Color::DarkGray };
+            let size_color = if icon.trim().is_empty() {
+                Color::Green
+            } else {
+                Color::DarkGray
+            };
             Row::new(vec![
                 Cell::from(icon.as_str()).style(Style::default().fg(*icon_color)),
                 Cell::from(name.as_str()).style(Style::default().fg(*name_color)),
@@ -193,21 +217,13 @@ fn render_browser(frame: &mut Frame, app: &mut App, area: ratatui::layout::Rect)
     ];
 
     let title = if app.search_active {
-        format!(
-            " {} [{} matches] ",
-            app.location_display(),
-            visible_len
-        )
+        format!(" {} [{} matches] ", app.location_display(), visible_len)
     } else {
         format!(" {} ", app.location_display())
     };
 
     let table = Table::new(rows, widths)
-        .block(
-            Block::bordered()
-                .title(title)
-                .border_style(border_style),
-        )
+        .block(Block::bordered().title(title).border_style(border_style))
         .column_spacing(1)
         .row_highlight_style(
             Style::default()
@@ -232,11 +248,59 @@ fn render_text_preview(frame: &mut Frame, app: &App, area: ratatui::layout::Rect
         let block = Block::bordered()
             .title(format!(" Preview: {} ", name))
             .border_style(Style::default().fg(Color::Cyan));
-        let content = Paragraph::new(Line::from(Span::styled(
-            "  Loading...",
-            Style::default().fg(Color::DarkGray),
-        )))
-        .block(block);
+        let lines = if let Some(progress) = &app.preview.progress {
+            let pct = progress
+                .total_bytes
+                .filter(|total| *total > 0)
+                .map(|total| {
+                    (progress.bytes_read as f64 / total as f64 * 100.0).clamp(0.0, 100.0) as u16
+                });
+            let bar_width = 24usize.min(area.width.saturating_sub(32) as usize).max(8);
+            let filled = pct
+                .map(|pct| (bar_width as f64 * pct as f64 / 100.0) as usize)
+                .unwrap_or(0)
+                .min(bar_width);
+            let bar = format!(
+                "{}{}",
+                "\u{2588}".repeat(filled),
+                "\u{2591}".repeat(bar_width - filled)
+            );
+            let total = progress
+                .total_bytes
+                .map(|total| humansize::format_size(total, humansize::BINARY))
+                .unwrap_or_else(|| "unknown".to_string());
+            let pct_text = pct
+                .map(|pct| format!(" {:>3}%", pct))
+                .unwrap_or_else(|| "     ".to_string());
+
+            vec![
+                Line::from(""),
+                Line::from(vec![
+                    Span::styled("  ", Style::default()),
+                    Span::styled(&progress.label, Style::default().fg(Color::Cyan)),
+                ]),
+                Line::from(vec![
+                    Span::raw("  ["),
+                    Span::styled(bar, Style::default().fg(Color::Green)),
+                    Span::raw("]"),
+                    Span::styled(pct_text, Style::default().fg(Color::White)),
+                ]),
+                Line::from(Span::styled(
+                    format!(
+                        "  {} / {} needed",
+                        humansize::format_size(progress.bytes_read, humansize::BINARY),
+                        total
+                    ),
+                    Style::default().fg(Color::DarkGray),
+                )),
+            ]
+        } else {
+            vec![Line::from(Span::styled(
+                "  Loading...",
+                Style::default().fg(Color::DarkGray),
+            ))]
+        };
+        let content = Paragraph::new(lines).block(block);
         frame.render_widget(content, area);
     } else if let Some(err) = &app.preview.error {
         let block = Block::bordered()
@@ -264,7 +328,10 @@ fn render_text_preview(frame: &mut Frame, app: &App, area: ratatui::layout::Rect
 
         let block = Block::bordered()
             .title(title)
-            .title_bottom(Line::from(" j/k scroll  Ctrl+d/u page  g/G top/bottom  q close ").style(Style::default().fg(Color::DarkGray)))
+            .title_bottom(
+                Line::from(" j/k scroll  Ctrl+d/u page  g/G top/bottom  C copy  q close ")
+                    .style(Style::default().fg(Color::DarkGray)),
+            )
             .border_style(Style::default().fg(Color::Cyan));
 
         let lines: Vec<Line> = text
@@ -349,6 +416,8 @@ fn render_metadata(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         .title(" Metadata ")
         .border_style(Style::default().fg(Color::DarkGray));
 
-    let paragraph = Paragraph::new(content).block(block).wrap(Wrap { trim: false });
+    let paragraph = Paragraph::new(content)
+        .block(block)
+        .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, area);
 }


### PR DESCRIPTION
## Summary

- add remote MCAP/SVO2 preview support using the MCAP SDK summary reader
- cache remote summary/index ranges so preview reads the footer plus summary tail instead of issuing many tiny S3 range requests
- show MCAP index read progress, render summary details, and allow copying the preview text with Shift+C
- add a repo knowledgebase documenting architecture, commands, and current implementation notes

## Validation

- cargo test --no-run
